### PR TITLE
Avoid browser tooltips in favor of social tooltips

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -54,6 +54,16 @@ jQuery(document).ready(function($) {
 		}).children( window.location.hash ? 'a[href="' + window.location.hash + '"]' : 'a:first' ).trigger('click');
 
 	})();
+
+/*  Disable browser tooltips (to use CSS tooltips)
+/* ----------------------------------------------- */	
+	  $(".social-tooltip").hover(function(){
+	    $(this).attr("tooltip-data", $(this).attr("title"));
+	    $(this).removeAttr("title");
+	  }, function(){
+	    $(this).attr("title", $(this).attr("tooltip-data"));
+	    $(this).removeAttr("tooltip-data");
+	  });
 	
 /*  Comments / pingbacks tabs
 /* ------------------------------------ */	

--- a/style.css
+++ b/style.css
@@ -583,7 +583,7 @@ box-shadow: inset 0 1px 1px rgba(0,0,0,0.4), 0 1px 0 rgba(255,255,255,0.03); }
 .social-links li a { display: block!important; position: relative; text-align: center; }
 .social-links .social-tooltip { color: #333; font-size: 24px; display: inline; position: relative; z-index: 98; }
 .social-links .social-tooltip:hover { color: #444; text-decoration: none; }
-.social-links .social-tooltip:hover:after { top: -36px; background: #eee; font-size: 14px; color: #666; content: attr(title); display: block; right: 0; padding: 5px 10px; position: absolute; white-space: nowrap; 
+.social-links .social-tooltip:hover:after { top: -36px; background: #eee; font-size: 14px; color: #666; content: attr(tooltip-data); display: block; right: 0; padding: 5px 10px; position: absolute; white-space: nowrap; 
 -webkit-border-radius: 3px; border-radius: 3px; }
 .social-links .social-tooltip:hover:before { top: -10px; right: 8px; border: solid; border-color: #eee transparent; border-width: 5px 5px 0 5px; content: ""; display: block; position: absolute; z-index: 1; }
 


### PR DESCRIPTION
Thanks a lot for your work! I'm suggesting this change, just in case you're interested.

Before:

![before](https://user-images.githubusercontent.com/652785/122485291-28208600-cf9c-11eb-920c-714ebad0792d.gif)

After:

![after](https://user-images.githubusercontent.com/652785/122485305-2ce53a00-cf9c-11eb-9bde-413f37e752d9.gif)
